### PR TITLE
add server side pdf-parser and email verification

### DIFF
--- a/apps/server/src/routers/auth.router.ts
+++ b/apps/server/src/routers/auth.router.ts
@@ -28,17 +28,22 @@ export default async function authRouter(
   const { supabase } = options;
   if (!supabase) throw new Error("Supabase client not initialized");
 
+    const emailRegex = /^[a-zA-Z0-9._%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
   // Login with email/password
   server.post("/login", async (req, res) => {
     try {
       const { email, password, captchaToken } = req.body as Static<typeof LoginSchema> & { captchaToken?: string };
-
       // Verify CAPTCHA if provided
       if (captchaToken) {
         const captchaValid = await verifyRecaptcha(captchaToken, req.ip);
         if (!captchaValid) {
           return res.status(400).send({ error: "Invalid CAPTCHA verification" });
         }
+      }
+
+      if (!emailRegex.test(email)) {
+        console.log("Invalid email format:", email);
+        return res.status(400).send({ error: "Invalid email format" });
       }
 
       // Authenticate with Supabase

--- a/apps/server/src/routers/stocks.router.ts
+++ b/apps/server/src/routers/stocks.router.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import type { FastifyCustomOptions } from "../types";
 import { randomBytes } from "crypto";
-import { PDFParse } from 'pdf-parse';
+
 
 // Simple CUID-like ID generator
 const generateId = () => `c${randomBytes(12).toString("base64url")}`;
@@ -353,21 +353,7 @@ export default async function stocksRouter(
         return res.status(400).send({ error: "No file uploaded" });
       }
 
-      const buffer = await data.toBuffer();
-
-      // Check pdf magic byte
-      if (buffer.slice(0, 5).toString() !== "%PDF-") {
-        return res.status(400).send({ error: "Failed to upload PDF" });
-      }
-
-      // Pdf parse check 
-      try {
-        const parser = new PDFParse({ data: buffer });
-        await parser.getText(); 
-        await parser.destroy();
-      } catch {
-        return res.status(400).send({ error: "Failed to upload PDF" });
-      }
+    const buffer = await data.toBuffer();
 
     const fileName = `stocks/${Date.now()}-${data.filename}`;
 

--- a/apps/server/src/routers/stocks.router.ts
+++ b/apps/server/src/routers/stocks.router.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import type { FastifyCustomOptions } from "../types";
 import { randomBytes } from "crypto";
+import { PDFParse } from 'pdf-parse';
 
 // Simple CUID-like ID generator
 const generateId = () => `c${randomBytes(12).toString("base64url")}`;
@@ -353,22 +354,36 @@ export default async function stocksRouter(
       }
 
       const buffer = await data.toBuffer();
-      const fileName = `stocks/${Date.now()}-${data.filename}`;
 
-      // Upload to Supabase Storage
-      const { data: uploadData, error: uploadError } = await supabase.storage
-        .from("research-pdfs")
-        .upload(fileName, buffer, {
-          contentType: data.mimetype,
-          upsert: false,
-        });
+      // Check pdf magic byte
+      if (buffer.slice(0, 5).toString() !== "%PDF-") {
+        return res.status(400).send({ error: "Failed to upload PDF" });
+      }
+
+      // Pdf parse check 
+      try {
+        const parser = new PDFParse({ data: buffer });
+        await parser.getText(); 
+        await parser.destroy();
+      } catch {
+        return res.status(400).send({ error: "Failed to upload PDF" });
+      }
+
+    const fileName = `stocks/${Date.now()}-${data.filename}`;
+
+      const { data: uploadData, error: uploadError } =
+        await supabase.storage
+          .from("research-pdfs")
+          .upload(fileName, buffer, {
+            contentType: "application/pdf",
+           upsert: false,
+          });
 
       if (uploadError) {
         req.log.error(uploadError);
         return res.status(500).send({ error: "Failed to upload PDF" });
       }
 
-      // Get public URL
       const { data: { publicUrl } } = supabase.storage
         .from("research-pdfs")
         .getPublicUrl(fileName);

--- a/apps/server/src/routers/waitlist.router.ts
+++ b/apps/server/src/routers/waitlist.router.ts
@@ -66,13 +66,18 @@ export default async function waitlistRouter(
     async (req, res) => {
       try {
         const { email, captchaToken } = req.body as Static<typeof JoinWaitlistSchema> & { captchaToken?: string };
-
+        const emailRegex = /^[a-zA-Z0-9._%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
         // Verify CAPTCHA if provided
         if (captchaToken) {
           const captchaValid = await verifyRecaptcha(captchaToken, req.ip);
           if (!captchaValid) {
             return res.status(400).send({ error: "Invalid CAPTCHA verification" });
           }
+        }
+
+        if (!emailRegex.test(email)) {
+          console.log("Invalid email format:", email);
+          return res.status(400).send({ error: "Invalid email format" });
         }
 
         // Check if email already exists

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "honestly-insight-hub",
@@ -7,6 +8,7 @@
         "@fastify/cookie": "^11.0.2",
         "@supabase/supabase-js": "^2.75.0",
         "esbuild": "0.21.5",
+        "pdf-parse": "^2.4.5",
       },
       "devDependencies": {
         "concurrently": "^8.2.2",
@@ -1231,7 +1233,9 @@
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
-    "pdfjs-dist": ["pdfjs-dist@5.3.93", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.71" } }, "sha512-w3fQKVL1oGn8FRyx5JUG5tnbblggDqyx2XzA5brsJ5hSuS+I0NdnJANhmeWKLjotdbPQucLBug5t0MeWr0AAdg=="],
+    "pdf-parse": ["pdf-parse@2.4.5", "", { "dependencies": { "@napi-rs/canvas": "0.1.80", "pdfjs-dist": "5.4.296" }, "bin": { "pdf-parse": "bin/cli.mjs" } }, "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg=="],
+
+    "pdfjs-dist": ["pdfjs-dist@5.4.296", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.80" } }, "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -1638,6 +1642,8 @@
     "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "react-pdf/pdfjs-dist": ["pdfjs-dist@5.3.93", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.71" } }, "sha512-w3fQKVL1oGn8FRyx5JUG5tnbblggDqyx2XzA5brsJ5hSuS+I0NdnJANhmeWKLjotdbPQucLBug5t0MeWr0AAdg=="],
 
     "tailwindcss/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@fastify/cookie": "^11.0.2",
     "@supabase/supabase-js": "^2.75.0",
-    "esbuild": "0.21.5"
+    "esbuild": "0.21.5",
+    "pdf-parse": "^2.4.5"
   }
 }


### PR DESCRIPTION
Added the following checks for added security
1. In auth.router.ts, added regex based email verification before passing it for verification 
2. In waitlits.router.ts also added the regex based verification
3. In stocks.router.ts, used pdf-parser to check the following aspects of a pdf file 
        a. First check magic bits of the file (%Pdf-)
        b. Parse the pdf and check if it is valid file or a corrupt file
4. Added the pdf-parse package in package.json
        