### PR TITLE
revert: set access_approved back to false on Approve & Invite

### DIFF
--- a/apps/server/src/routers/waitlist.router.ts
+++ b/apps/server/src/routers/waitlist.router.ts
@@ -236,7 +236,7 @@ export default async function waitlistRouter(
           .insert({
             user_id: authData.user.id,
             role: "subscriber",
-            access_approved: true, // Admin has already approved by clicking "Approve & Invite"
+            access_approved: false, // Subscribers need approval after profile completion
             invited_by: invitedBy,
             contact_method: "email",
             profile_completed: false,


### PR DESCRIPTION
Reverts the previous change that set access_approved to true when an admin clicks "Approve & Invite". Subscribers still need approval after profile completion.